### PR TITLE
[HOPSWORKS-926] Remove Airflow devel_hadoop which brings snakebite[ke…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,8 +38,8 @@ default['sqoop']['url']               = "#{node['download_url']}/sqoop-#{node['s
 default["sqoop"]["port"]              = "16000"
 
 
-
-default['airflow']["operators"]       = "hive,mysql,kubernetes,password,hdfs,slack,ssh,jdbc,mysql,devel_hadoop,crypto"
+## Remove devel_hadoop which brings snakebite[kerberos] which does not work on Python 3
+default['airflow']["operators"]       = "hive,mysql,kubernetes,password,hdfs,slack,ssh,jdbc,mysql,crypto"
 
 #default['airflow']["user_uid"] = 9999
 #default['airflow']["group_gid"] = 9999

--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -52,10 +52,6 @@ default['airflow']['packages'] =
     statsd: [{ name: 'statsd', version: '>=3.0.1' }],
     vertica: [{ name: 'vertica-python', version: '>=0.5.1' }],
     ldap: [{ name: 'ldap3', version: '>=0.9.9.1' }],
-    kerberos: [{ name: 'pykerberos', version: '>=1.1.8' },
-               { name: 'thrift_sasl', version: '>=0.2.0' },
-               #{ name: 'snakebite[kerberos]', version: '>=2.7.8' }
-              ],
     password: [{ name: 'bcrypt', version: '>=2.0.0' },
                { name: 'flask-bcrypt', version: '>=0.7.1' }],
     github_enterprise: [{ name: 'Flask-OAuthlib', version: '>=0.9.1' }],
@@ -75,7 +71,7 @@ default['airflow']['packages'] =
 # OS packages needed for the above python packages.
 default['airflow']['dependencies'] =
   {
-    ubuntu:
+    debian:
     {
       default: [{ name: 'python-dev', version: '' },
                 { name: 'build-essential', version: '' },
@@ -94,11 +90,10 @@ default['airflow']['dependencies'] =
       webhdfs: [{ name: 'libkrb5-dev', version: '' }],
       kerberos: [{ name: 'libsasl2-dev', version: '' }]
     },
-    centos:
+    rhel:
     {
       default: [{ name: 'gcc', version: '' },
                 { name: 'gcc-c++', version: '' },
-                { name: 'epel-release', version: '' },
                 { name: 'libjpeg-devel', version: '' },
                 { name: 'zlib-devel', version: '' },
                 { name: 'python-devel', version: '' }],

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -19,7 +19,12 @@
 #end
 
 # Obtain the current platform name
-platform = node['platform'].to_s
+platform = node['platform_family'].to_s
+
+if platform == 'rhel' and node['rhel']['epel'].downcase == "true"
+  epel_release = { name: 'epel-release', version: ''}
+  node.default['airflow']['dependencies'][platform][:default] << epel_release
+end
 
 # Default dependencies to install
 dependencies_to_install = []


### PR DESCRIPTION
…rberos] and it does not work with Py3. Fix platform family name and flag for installing epel-release

https://logicalclocks.atlassian.net/browse/HOPSWORKS-926