### PR TITLE
[HOPSWORKS-1328] Change libjpeg-devel name for RHEL distributions

### DIFF
--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -95,7 +95,7 @@ default['airflow']['dependencies'] =
     {
       default: [{ name: 'gcc', version: '' },
                 { name: 'gcc-c++', version: '' },
-                { name: 'libjpeg-devel', version: '' },
+                { name: 'libjpeg-turbo-devel', version: '' },
                 { name: 'zlib-devel', version: '' },
                 { name: 'python-devel', version: '' }],
       mysql: [{ name: 'mariadb', version: '' },


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1328