### PR TITLE
Setuptools pin version, Ignore Failure

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -16,10 +16,10 @@ source "https://supermarket.chef.io"
 
 metadata
 
-cookbook 'kagent', github: "logicalclocks/kagent-chef", branch: "master"
-cookbook 'hops', github: "logicalclocks/hops-hadoop-chef", branch: "master"
-cookbook 'ndb', github: "logicalclocks/ndb-chef", branch: "master"
-cookbook 'conda', github: "logicalclocks/conda-chef", branch: "master"
-cookbook 'hive2', github: "logicalclocks/hive-chef", branch: "master"
-cookbook 'consul', github: "logicalclocks/consul-chef", branch: "master"
+cookbook 'kagent', github: "logicalclocks/kagent-chef", branch: "2.3"
+cookbook 'hops', github: "logicalclocks/hops-hadoop-chef", branch: "2.3"
+cookbook 'ndb', github: "logicalclocks/ndb-chef", branch: "2.3"
+cookbook 'conda', github: "logicalclocks/conda-chef", branch: "2.3"
+cookbook 'hive2', github: "logicalclocks/hive-chef", branch: "2.3"
+cookbook 'consul', github: "logicalclocks/consul-chef", branch: "2.3"
 cookbook 'java', github: "logicalclocks/java", branch: "v7.0.0-1"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -67,7 +67,8 @@ bash 'init_airflow_db' do
   code <<-EOF
       set -e
       export AIRFLOW_HOME=#{node['airflow']['base_dir']}
-      #{node['airflow']['bin_path']}/airflow db upgrade
+#      #{node['airflow']['bin_path']}/airflow db upgrade
+      #{node['airflow']['bin_path']}/airflow upgradedb
     EOF
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -67,7 +67,7 @@ bash 'init_airflow_db' do
   code <<-EOF
       set -e
       export AIRFLOW_HOME=#{node['airflow']['base_dir']}
-      #{node['airflow']['bin_path']}/airflow upgradedb
+      #{node['airflow']['bin_path']}/airflow db upgrade
     EOF
 end
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -122,6 +122,7 @@ for operator in node['airflow']['operators'].split(",")
     umask "022"
     user node['conda']['user']
     group node['conda']['group']
+    ignore_failure true
     environment ({'SLUGIFY_USES_TEXT_UNIDECODE' => 'yes',
                   'AIRFLOW_HOME' => node['airflow']['base_dir']})
     code <<-EOF

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -107,9 +107,11 @@ bash 'install_airflow' do
                 'HOME' => "/home/#{node['conda']['user']}"})
   cwd "/home/#{node['conda']['user']}"
   code <<-EOF
-      set -e
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']}
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir airflow-exporter==1.3.0
+#      set -e
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir setuptools==56.2.0 -y
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']} --upgrade-strategy only-if-needed -y
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir Flask-OpenID==1.2.5 -y
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir airflow-exporter==1.3.0 -y
     EOF
 end
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -108,10 +108,12 @@ bash 'install_airflow' do
   cwd "/home/#{node['conda']['user']}"
   code <<-EOF
 #      set -e
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir setuptools==56.2.0 -y
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']} --upgrade-strategy only-if-needed -y
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir Flask-OpenID==1.2.5 -y
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir airflow-exporter==1.3.0 -y
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir setuptools==56.2.0 
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir Flask-OpenID==1.2.5
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir flask-appbuilder==2.2 --upgrade-strategy only-if-needed
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']} --upgrade-strategy only-if-needed
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir mysqlclient
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir airflow-exporter==1.3.0
     EOF
 end
 
@@ -123,7 +125,7 @@ for operator in node['airflow']['operators'].split(",")
     environment ({'SLUGIFY_USES_TEXT_UNIDECODE' => 'yes',
                   'AIRFLOW_HOME' => node['airflow']['base_dir']})
     code <<-EOF
-      set -e
+      #set -e
       #{node['conda']['base_dir']}/envs/airflow/bin/pip install apache-airflow["#{operator}"]==#{node['airflow']['version']} --constraint #{node['airflow']['url']}
     EOF
   end

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -108,11 +108,11 @@ bash 'install_airflow' do
   cwd "/home/#{node['conda']['user']}"
   code <<-EOF
 #      set -e
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir setuptools==56.2.0 
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir Flask-OpenID==1.2.5
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir flask-appbuilder==2.2 --upgrade-strategy only-if-needed
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']} --upgrade-strategy only-if-needed
-      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir mysqlclient
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir setuptools==57.0.5
+#      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir Flask-OpenID==1.2.5
+#      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir flask-appbuilder==2.2 --upgrade-strategy only-if-needed
+      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']}
+#      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir mysqlclient
       #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir airflow-exporter==1.3.0
     EOF
 end

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -102,6 +102,7 @@ bash 'install_airflow' do
   umask "022"
   user node['conda']['user']
   group node['conda']['group']
+  ignore_failure true
   environment ({'SLUGIFY_USES_TEXT_UNIDECODE' => 'yes',
                 'AIRFLOW_HOME' => node['airflow']['base_dir'],
                 'HOME' => "/home/#{node['conda']['user']}"})
@@ -109,10 +110,7 @@ bash 'install_airflow' do
   code <<-EOF
 #      set -e
       #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir setuptools==57.0.5
-#      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir Flask-OpenID==1.2.5
-#      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir flask-appbuilder==2.2 --upgrade-strategy only-if-needed
       #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir apache-airflow==#{node['airflow']['version']} --constraint #{node['airflow']['url']}
-#      #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir mysqlclient
       #{node['conda']['base_dir']}/envs/airflow/bin/pip install --no-cache-dir airflow-exporter==1.3.0
     EOF
 end


### PR DESCRIPTION
Airflow doesn't pin the version of setuptools, and when setuptools > version 58, we get an installation error on Flask-OpenID. See here for details on the setuptools problem:
https://exerror.com/error-in-mongoengine-setup-command-use_2to3-is-invalid/